### PR TITLE
Fix NOW deployments - NODE_ENV=production

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "debug": "npm run build && node --inspect ./lib/index.js",
     "lighthouse:visual": "lighthouse http://localhost:3000/ --view",
     "lighthouse": "npm run build && node ./scripts/lighthouse.js",
-    "deploy": "now --public -e NODE_ENV=production",
+    "now-build": "NODE_ENV=production npm run build",
+    "now-start": "NODE_ENV=production npm start",
+    "deploy": "now --public",
     "deploy:alias": "now alias `pbpaste` hackernewspwa.com"
   },
   "keywords": [],


### PR DESCRIPTION
`npm run deploy` no longer works because NOW won't install devDeps, which are required for `npm run build`.

This previously worked because NOW was using the now deleted package-lock.json.

I still wanted to use `NODE_ENV=production` so I use seperate `now-{cmd}` to supply it.