### PR TITLE
Replace speech mark with backtick and remove trailing spaces in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This will build the project and serve it locally at `http://localhost:3000`
 * [React](https://reactjs.org/)
 * [Redux](https://redux.js.org/)
 * [Babel](https://babeljs.io/)
-* [Node-Sass](https://github.com/sass/node-sass) 
+* [Node-Sass](https://github.com/sass/node-sass)
 * [WebPack](https://webpack.js.org/)
 * [Service Worker API](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)
 
@@ -69,7 +69,7 @@ The majority of the project's source files are found here. They are separated in
 
 The Node server runs on port `3000` by default. Depending on the route being requested it will either return a rendered page or else act as an API to the React `client`.
 
-Server Side Rendering is handled by the `renderAppShell` method in `server/app-shell-handler'. This works by generating the React application on the server side into the variable `html`, which is then inserted into the response along with the application's initial state. 
+Server Side Rendering is handled by the `renderAppShell` method in `server/app-shell-handler`. This works by generating the React application on the server side into the variable `html`, which is then inserted into the response along with the application's initial state.
 
 The server uses Node for both serving static assets (from the `build` folder) and server-side rendering. This means the app works in situations where JavaScript may not be available. This could be search engine crawlers or even just situations where JavaScript fails or is blocked by a network.
 
@@ -79,7 +79,7 @@ To bootstrap the app on the client side, the server applies `__INITIAL_STATE__` 
 
 This initial state is used with `client/js/app-shell` which passes this data to `initialState` within the `configureStore` method. When the serverside rendering has set the initial state, this data [rehydrates](https://reactjs.org/docs/react-dom.html#hydrate) the `client` part of the app so that it can then continue on the client side.
 
-If you are not using serverside rendering on your project, the `componentDidMount` method in `app/containers/PageLoader` falls back to fetching data as needed on the client side. 
+If you are not using serverside rendering on your project, the `componentDidMount` method in `app/containers/PageLoader` falls back to fetching data as needed on the client side.
 
 ##### Manifest.json
 
@@ -91,7 +91,7 @@ The `client` folder contains static images, styles and JavaScript for the React 
 
 The `js` folder contains two files, `sw.js` that sets up a [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) and `app-shell.js` that renders the React app.
 
-The service worker is used to cache API responses so that should the internet connection be disrupted, any previously requested data will be served locally. 
+The service worker is used to cache API responses so that should the internet connection be disrupted, any previously requested data will be served locally.
 
 The `app-shell.js` file renders the "App Shell" component, which houses the route information and any local data, passing it along to child components for display.
 
@@ -103,11 +103,11 @@ The main part of the React app is in this folder, including `components` (the na
 
 ##### Pages
 
-Within the context of the app, each page is represented by it's own `pages/[page]` file. This helps in debugging, in terms of isolating issues that might be happening within one section of the site, and can be useful when defining rules for [code splitting](https://reactjs.org/docs/code-splitting.html). 
+Within the context of the app, each page is represented by it's own `pages/[page]` file. This helps in debugging, in terms of isolating issues that might be happening within one section of the site, and can be useful when defining rules for [code splitting](https://reactjs.org/docs/code-splitting.html).
 
 ##### PageLoader.js
 
-Within the app's `containers` most of the data fetching and handling occurs within `PageLoader`. 
+Within the app's `containers` most of the data fetching and handling occurs within `PageLoader`.
 
 Redux is not required, but is used to make API data available throughout the application. Your app may use an alternative approach. In this case, the `_fetchData` method makes use of [React router's `matchRoutes` API](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-config/README.md).
 


### PR DESCRIPTION
Just a small fix on line [72](https://github.com/nearform/react-pwa/compare/tiny-readme-fix?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R72) to replace the ` ' ` with `` ` `` which was causing formatting issues.

My editor removed any trailing whitespace which is why there are a few more changes here.