### PR TITLE
FIX: loading animation overflows parent container

### DIFF
--- a/src/client/js/components/Comments/Comments.jsx
+++ b/src/client/js/components/Comments/Comments.jsx
@@ -15,9 +15,10 @@ const styles = stylesheet({
     listStyle: 'none',
     margin: 0,
     padding: '1em',
-    overflowX: 'hidden',
   },
   commentsListItem: {
+    position: 'relative',
+    overflow: 'hidden',
     lineHeight: '10pt',
   },
   commentsListTitle: {

--- a/src/client/js/components/Comments/__snapshots__/Comments.test.jsx.snap
+++ b/src/client/js/components/Comments/__snapshots__/Comments.test.jsx.snap
@@ -2,10 +2,10 @@
 
 exports[`renders correctly when data provided 1`] = `
 <ul
-  class="commentsList_fah75xl"
+  class="commentsList_f1azx7cb"
 >
   <li
-    class="commentsListItem_fiyvqli"
+    class="commentsListItem_f1y5xtod"
   >
     <span
       class="commentsListTitle_f1bz5gy2"
@@ -28,7 +28,7 @@ exports[`renders correctly when data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli"
+    class="commentsListItem_f1y5xtod"
   >
     <span
       class="commentsListTitle_f1bz5gy2"
@@ -52,7 +52,7 @@ exports[`renders correctly when data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli"
+    class="commentsListItem_f1y5xtod"
   >
     <span
       class="commentsListTitle_f1bz5gy2"
@@ -72,7 +72,7 @@ exports[`renders correctly when data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli"
+    class="commentsListItem_f1y5xtod"
   >
     <span
       class="commentsListTitle_f1bz5gy2"
@@ -89,7 +89,7 @@ exports[`renders correctly when data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli"
+    class="commentsListItem_f1y5xtod"
   >
     <span
       class="commentsListTitle_f1bz5gy2"
@@ -109,7 +109,7 @@ exports[`renders correctly when data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli"
+    class="commentsListItem_f1y5xtod"
   >
     <span
       class="commentsListTitle_f1bz5gy2"
@@ -135,7 +135,7 @@ exports[`renders correctly when data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli"
+    class="commentsListItem_f1y5xtod"
   >
     <span
       class="commentsListTitle_f1bz5gy2"
@@ -155,7 +155,7 @@ exports[`renders correctly when data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli"
+    class="commentsListItem_f1y5xtod"
   >
     <span
       class="commentsListTitle_f1bz5gy2"
@@ -175,7 +175,7 @@ exports[`renders correctly when data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli"
+    class="commentsListItem_f1y5xtod"
   >
     <span
       class="commentsListTitle_f1bz5gy2"
@@ -192,7 +192,7 @@ exports[`renders correctly when data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli"
+    class="commentsListItem_f1y5xtod"
   >
     <span
       class="commentsListTitle_f1bz5gy2"
@@ -221,10 +221,10 @@ exports[`renders correctly when empty data provided 1`] = `
 
 exports[`renders correctly when no data provided 1`] = `
 <ul
-  class="commentsList_fah75xl"
+  class="commentsList_f1azx7cb"
 >
   <li
-    class="commentsListItem_fiyvqli loading_fmjor1"
+    class="commentsListItem_f1y5xtod loading_f1712lg4"
   >
     <span
       class="commentsListTitle_f1bz5gy2 placeholder_fu1ixcy"
@@ -248,7 +248,7 @@ exports[`renders correctly when no data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli loading_fmjor1"
+    class="commentsListItem_f1y5xtod loading_f1712lg4"
   >
     <span
       class="commentsListTitle_f1bz5gy2 placeholder_fu1ixcy"
@@ -272,7 +272,7 @@ exports[`renders correctly when no data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli loading_fmjor1"
+    class="commentsListItem_f1y5xtod loading_f1712lg4"
   >
     <span
       class="commentsListTitle_f1bz5gy2 placeholder_fu1ixcy"
@@ -296,7 +296,7 @@ exports[`renders correctly when no data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli loading_fmjor1"
+    class="commentsListItem_f1y5xtod loading_f1712lg4"
   >
     <span
       class="commentsListTitle_f1bz5gy2 placeholder_fu1ixcy"
@@ -320,7 +320,7 @@ exports[`renders correctly when no data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli loading_fmjor1"
+    class="commentsListItem_f1y5xtod loading_f1712lg4"
   >
     <span
       class="commentsListTitle_f1bz5gy2 placeholder_fu1ixcy"
@@ -344,7 +344,7 @@ exports[`renders correctly when no data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli loading_fmjor1"
+    class="commentsListItem_f1y5xtod loading_f1712lg4"
   >
     <span
       class="commentsListTitle_f1bz5gy2 placeholder_fu1ixcy"
@@ -368,7 +368,7 @@ exports[`renders correctly when no data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli loading_fmjor1"
+    class="commentsListItem_f1y5xtod loading_f1712lg4"
   >
     <span
       class="commentsListTitle_f1bz5gy2 placeholder_fu1ixcy"
@@ -392,7 +392,7 @@ exports[`renders correctly when no data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli loading_fmjor1"
+    class="commentsListItem_f1y5xtod loading_f1712lg4"
   >
     <span
       class="commentsListTitle_f1bz5gy2 placeholder_fu1ixcy"
@@ -416,7 +416,7 @@ exports[`renders correctly when no data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli loading_fmjor1"
+    class="commentsListItem_f1y5xtod loading_f1712lg4"
   >
     <span
       class="commentsListTitle_f1bz5gy2 placeholder_fu1ixcy"
@@ -440,7 +440,7 @@ exports[`renders correctly when no data provided 1`] = `
     </span>
   </li>
   <li
-    class="commentsListItem_fiyvqli loading_fmjor1"
+    class="commentsListItem_f1y5xtod loading_f1712lg4"
   >
     <span
       class="commentsListTitle_f1bz5gy2 placeholder_fu1ixcy"

--- a/src/client/js/components/More/More.jsx
+++ b/src/client/js/components/More/More.jsx
@@ -40,6 +40,7 @@ const styles = stylesheet({
     padding: '1em',
     borderBottom: `6px solid ${colors.NEARFORM_BRAND_MAIN}`,
     position: 'sticky',
+    zIndex: 1,
     top: '70px', // Height of the header TODO: should be shared constant
   },
   moreItem: {

--- a/src/client/js/components/More/__snapshots__/More.test.jsx.snap
+++ b/src/client/js/components/More/__snapshots__/More.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`renders correctly when end of list reached 1`] = `
 <div
-  class="more_f1wasfrc"
+  class="more_fvrfzw1"
 >
   <span>
     31 - 60
@@ -23,7 +23,7 @@ exports[`renders correctly when end of list reached 1`] = `
 
 exports[`renders correctly when location is "/" 1`] = `
 <div
-  class="more_f1wasfrc"
+  class="more_fvrfzw1"
 >
   <span>
     1 - 30
@@ -44,7 +44,7 @@ exports[`renders correctly when location is "/" 1`] = `
 
 exports[`renders correctly when location is "/newcomments" 1`] = `
 <div
-  class="more_f1wasfrc"
+  class="more_fvrfzw1"
 >
   <span>
     1 - 30
@@ -65,7 +65,7 @@ exports[`renders correctly when location is "/newcomments" 1`] = `
 
 exports[`renders correctly when location is "/newcomments/page/2" 1`] = `
 <div
-  class="more_f1wasfrc"
+  class="more_fvrfzw1"
 >
   <span>
     31 - 60
@@ -87,7 +87,7 @@ exports[`renders correctly when location is "/newcomments/page/2" 1`] = `
 
 exports[`renders correctly when location is "/page/5" 1`] = `
 <div
-  class="more_f1wasfrc"
+  class="more_fvrfzw1"
 >
   <span>
     121 - 150

--- a/src/client/js/components/Stories/Stories.jsx
+++ b/src/client/js/components/Stories/Stories.jsx
@@ -34,6 +34,8 @@ const styles = stylesheet({
     ).$nest,
   },
   storiesListItem: {
+    position: 'relative',
+    overflow: 'hidden',
     padding: '1em 0 0 0',
     display: 'grid',
     gridRowGap: '.5em',

--- a/src/client/js/components/Stories/__snapshots__/Stories.test.jsx.snap
+++ b/src/client/js/components/Stories/__snapshots__/Stories.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`renders correctly when data and page provided 1`] = `
   start="31"
 >
   <li
-    class="storiesListItem_f1h5zrli"
+    class="storiesListItem_fq4lpe5"
   >
     <div
       class="storiesListIndex_f1rppnmc"
@@ -29,7 +29,7 @@ exports[`renders correctly when data and page provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli"
+    class="storiesListItem_fq4lpe5"
   >
     <div
       class="storiesListIndex_f1rppnmc"
@@ -52,7 +52,7 @@ exports[`renders correctly when data and page provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli"
+    class="storiesListItem_fq4lpe5"
   >
     <div
       class="storiesListIndex_f1rppnmc"
@@ -75,7 +75,7 @@ exports[`renders correctly when data and page provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli"
+    class="storiesListItem_fq4lpe5"
   >
     <div
       class="storiesListIndex_f1rppnmc"
@@ -98,7 +98,7 @@ exports[`renders correctly when data and page provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli"
+    class="storiesListItem_fq4lpe5"
   >
     <div
       class="storiesListIndex_f1rppnmc"
@@ -129,7 +129,7 @@ exports[`renders correctly when data provided 1`] = `
   start="1"
 >
   <li
-    class="storiesListItem_f1h5zrli"
+    class="storiesListItem_fq4lpe5"
   >
     <div
       class="storiesListIndex_f1rppnmc"
@@ -152,7 +152,7 @@ exports[`renders correctly when data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli"
+    class="storiesListItem_fq4lpe5"
   >
     <div
       class="storiesListIndex_f1rppnmc"
@@ -175,7 +175,7 @@ exports[`renders correctly when data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli"
+    class="storiesListItem_fq4lpe5"
   >
     <div
       class="storiesListIndex_f1rppnmc"
@@ -198,7 +198,7 @@ exports[`renders correctly when data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli"
+    class="storiesListItem_fq4lpe5"
   >
     <div
       class="storiesListIndex_f1rppnmc"
@@ -221,7 +221,7 @@ exports[`renders correctly when data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli"
+    class="storiesListItem_fq4lpe5"
   >
     <div
       class="storiesListIndex_f1rppnmc"
@@ -259,7 +259,7 @@ exports[`renders correctly when no data provided 1`] = `
   class="storiesList_flhhfk0"
 >
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -286,7 +286,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -313,7 +313,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -340,7 +340,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -367,7 +367,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -394,7 +394,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -421,7 +421,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -448,7 +448,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -475,7 +475,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -502,7 +502,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -529,7 +529,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -556,7 +556,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -583,7 +583,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -610,7 +610,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -637,7 +637,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -664,7 +664,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -691,7 +691,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -718,7 +718,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -745,7 +745,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"
@@ -772,7 +772,7 @@ exports[`renders correctly when no data provided 1`] = `
     </div>
   </li>
   <li
-    class="storiesListItem_f1h5zrli loading_fmjor1"
+    class="storiesListItem_fq4lpe5 loading_f1712lg4"
   >
     <div
       class="storiesListIndex_f1rppnmc placeholder_fu1ixcy"

--- a/src/client/js/styles/common.js
+++ b/src/client/js/styles/common.js
@@ -30,9 +30,10 @@ export const loadingAnimation = style(debugClassName('loading'), {
     '&::after': {
       content: "''",
       position: 'absolute',
+      top: 0,
       width: '100%',
       height: '100%',
-      background: 'linear-gradient(90deg, rgba(0,0,0,0), rgba(255,255,255,0.15), rgba(0,0,0,0))',
+      background: 'linear-gradient(90deg, rgba(0,0,0,0), rgba(255,255,255,0.25), rgba(0,0,0,0))',
       transform: 'translateX(-100%)',
       animationName: keyframes({
         '100%': {


### PR DESCRIPTION
https://github.com/nearform/react-pwa/issues/76

+ fixes that 'More' panel stays on top of the content while sticky