### PR TITLE
Issue-88: add to homescreen prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4396,6 +4396,11 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -5238,24 +5243,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5265,12 +5274,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -5279,34 +5290,40 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5315,25 +5332,29 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5342,13 +5363,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5364,7 +5387,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5378,13 +5402,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5393,7 +5419,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5402,7 +5429,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5412,18 +5440,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -5431,13 +5462,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -5445,12 +5478,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -5459,7 +5494,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5468,7 +5504,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -5476,13 +5513,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5493,7 +5532,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5511,7 +5551,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5521,13 +5562,15 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5537,7 +5580,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5549,18 +5593,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -5568,19 +5615,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5590,19 +5640,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5614,7 +5667,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -5622,7 +5676,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5637,7 +5692,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5646,42 +5702,49 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -5691,7 +5754,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5700,7 +5764,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5708,13 +5773,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5729,13 +5796,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5744,12 +5813,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
       }
@@ -10748,14 +10819,25 @@
       }
     },
     "react": {
-      "version": "16.7.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.7.0-alpha.2.tgz",
-      "integrity": "sha512-Xh1CC8KkqIojhC+LFXd21jxlVtzoVYdGnQAi/I2+dxbmos9ghbx5TQf9/nDxc4WxaFfUQJkya0w1k6rMeyIaxQ==",
+      "version": "16.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.0-alpha.1.tgz",
+      "integrity": "sha512-vLwwnhM2dXrCsiQmcSxF2UdZVV5xsiXjK5Yetmy8dVqngJhQ3aw3YJhZN/YmyonxwdimH40wVqFQfsl4gSu2RA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0-alpha.2"
+        "scheduler": "^0.13.0-alpha.1"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.13.0-alpha.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.0-alpha.1.tgz",
+          "integrity": "sha512-W0sH0848sVuPKg+I18vTYQyzVtA4X1lrVgSeXK6KnOPUltFdJcY5nkbTkjGUeS/E0x+eBsNYfSdhJtGjT95njw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-clientside-effect": {
@@ -10768,14 +10850,25 @@
       }
     },
     "react-dom": {
-      "version": "16.7.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0-alpha.2.tgz",
-      "integrity": "sha512-o0mMw8jBlwHjGZEy/vvKd/6giAX0+skREMOTs3/QHmgi+yAhUClp4My4Z9lsKy3SXV+03uPdm1l/QM7NTcGuMw==",
+      "version": "16.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.0-alpha.1.tgz",
+      "integrity": "sha512-tZCUM8BpnwUHJmLnUWP9c3vVZxnCqYotj7s4tx7umojG6BKv745KIBtuPTzt0EI0q50GMLEpmT/CPQ8iA61TwQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0-alpha.2"
+        "scheduler": "^0.13.0-alpha.1"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.13.0-alpha.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.0-alpha.1.tgz",
+          "integrity": "sha512-W0sH0848sVuPKg+I18vTYQyzVtA4X1lrVgSeXK6KnOPUltFdJcY5nkbTkjGUeS/E0x+eBsNYfSdhJtGjT95njw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-focus-lock": {
@@ -11455,6 +11548,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
       "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -49,14 +49,15 @@
     ]
   },
   "dependencies": {
+    "exenv": "^1.2.2",
     "fastify": "^1.13.3",
     "fastify-compress": "^0.7.1",
     "fastify-static": "^1.0.0",
     "history": "^4.7.2",
     "memory-cache": "^0.2.0",
     "node-fetch": "^2.3.0",
-    "react": "^16.7.0-alpha.2",
-    "react-dom": "^16.7.0-alpha.2",
+    "react": "^16.8.0-alpha.1",
+    "react-dom": "^16.8.0-alpha.1",
     "react-focus-lock": "^1.17.6",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",

--- a/src/client/js/AppShell.jsx
+++ b/src/client/js/AppShell.jsx
@@ -1,9 +1,11 @@
 import React, { useState, useCallback } from 'react'
 import { Router as ServerRouter, Switch } from 'react-router'
 import { BrowserRouter, Route } from 'react-router-dom'
+import env from 'exenv'
 import routes from '../routes'
 import SkipLinks from './components/SkipLinks'
 import Header from './components/Header'
+import AddToHomescreen from './components/AddToHomescreen'
 
 export function AppShell({ history, ssrPreloading }) {
   const [navigationVisible, setNavigationVisible] = useState(false)
@@ -16,7 +18,7 @@ export function AppShell({ history, ssrPreloading }) {
     )
   }, [])
 
-  const SelectedRouter = typeof window === 'undefined' ? ServerRouter : BrowserRouter
+  const SelectedRouter = env.canUseDOM ? BrowserRouter : ServerRouter
 
   return (
     <SelectedRouter history={history}>
@@ -34,6 +36,7 @@ export function AppShell({ history, ssrPreloading }) {
             />
           ))}
         </Switch>
+        <AddToHomescreen />
       </>
     </SelectedRouter>
   )

--- a/src/client/js/components/AddToHomescreen/AddToHomescreen.jsx
+++ b/src/client/js/components/AddToHomescreen/AddToHomescreen.jsx
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react'
+import env from 'exenv'
+import Prompt from './Prompt'
+import { useBeforeInstallPrompt } from '../../hooks'
+
+const isMobile = env.canUseDOM
+  ? Boolean(navigator.userAgent.match(/Android|iPhone|iPad|iPod|Opera Mini|IEMobile/i))
+  : false
+
+function AddToHomescreen(props) {
+  const { prompt, promptToInstall, promptSupported } = useBeforeInstallPrompt()
+  const [render, setRender] = useState(false)
+  const [displayPrompt, setDisplayPrompt] = useState(false)
+
+  // hack to not render anything on server side
+  // effects are not run on server
+  useEffect(() => {
+    setRender(true)
+  }, [])
+
+  useEffect(
+    () => {
+      if (prompt || (!promptSupported && isMobile)) {
+        return setDisplayPrompt(true)
+      }
+    },
+    [prompt]
+  )
+
+  const hidePromptUI = () => setDisplayPrompt(false)
+  const promptToInstallAndHide = () => {
+    promptToInstall()
+    hidePromptUI()
+  }
+
+  return render ? (
+    <Prompt
+      display={displayPrompt}
+      onInstall={promptToInstallAndHide}
+      onDismiss={hidePromptUI}
+      nativeSupport={promptSupported}
+    />
+  ) : null
+}
+
+export default AddToHomescreen

--- a/src/client/js/components/AddToHomescreen/AddToHomescreen.jsx
+++ b/src/client/js/components/AddToHomescreen/AddToHomescreen.jsx
@@ -3,24 +3,23 @@ import env from 'exenv'
 import Prompt from './Prompt'
 import { useBeforeInstallPrompt } from '../../hooks'
 
-const isMobile = env.canUseDOM
-  ? Boolean(navigator.userAgent.match(/Android|iPhone|iPad|iPod|Opera Mini|IEMobile/i))
-  : false
-
-function AddToHomescreen(props) {
-  const { prompt, promptToInstall, promptSupported } = useBeforeInstallPrompt()
+function AddToHomescreen() {
+  const { prompt, promptToInstall, nativeSupport } = useBeforeInstallPrompt()
   const [render, setRender] = useState(false)
   const [displayPrompt, setDisplayPrompt] = useState(false)
+  const isMobile = env.canUseDOM
+    ? Boolean(navigator.userAgent.match(/Android|iPhone|iPad|iPod|Opera Mini|IEMobile/i))
+    : false
 
-  // hack to not render anything on server side
-  // effects are not run on server
+  // this causes that render is not set on the server
+  // therefore we first render null on both server and client
   useEffect(() => {
     setRender(true)
   }, [])
 
   useEffect(
     () => {
-      if (prompt || (!promptSupported && isMobile)) {
+      if (prompt || (!nativeSupport && isMobile)) {
         return setDisplayPrompt(true)
       }
     },
@@ -38,7 +37,7 @@ function AddToHomescreen(props) {
       display={displayPrompt}
       onInstall={promptToInstallAndHide}
       onDismiss={hidePromptUI}
-      nativeSupport={promptSupported}
+      nativeSupport={nativeSupport}
     />
   ) : null
 }

--- a/src/client/js/components/AddToHomescreen/AddToHomescreen.jsx
+++ b/src/client/js/components/AddToHomescreen/AddToHomescreen.jsx
@@ -19,7 +19,7 @@ function AddToHomescreen() {
 
   useEffect(
     () => {
-      if (prompt || (!nativeSupport && isMobile)) {
+      if (prompt || (!nativeSupport && isMobile && !navigator.standalone)) {
         return setDisplayPrompt(true)
       }
     },

--- a/src/client/js/components/AddToHomescreen/Prompt.jsx
+++ b/src/client/js/components/AddToHomescreen/Prompt.jsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react'
+import { Transition } from 'react-transition-group'
+import { media, stylesheet, classes } from 'typestyle'
+import { colors, buttonReset, ergonomics } from '../../styles/common'
+
+const styles = stylesheet({
+  wrapper: {
+    visibility: 'hidden',
+    transform: 'translateY(100%)',
+    transition: 'transform .3s cubic-bezier(.25, .8, .25, 1)',
+    position: 'fixed',
+    bottom: 0,
+    width: '100%',
+    padding: '1em',
+    background: colors.LIGHTEST_GRAY,
+    boxSizing: 'border-box',
+  },
+  title: {
+    margin: 0,
+    marginBottom: '1em',
+    fontSize: '1em',
+    fontWeight: 'normal',
+  },
+  buttons: {
+    display: 'flex',
+    flexDirection: 'column',
+    ...media(
+      {
+        minWidth: ergonomics.LAP.BEGINNING,
+      },
+      {
+        flexDirection: 'row',
+      }
+    ),
+  },
+  button: {
+    ...buttonReset,
+    padding: '.5em 1em',
+    background: colors.NEARFORM_BRAND_MAIN,
+    color: 'white',
+    fontSize: '1.1em',
+  },
+  installButton: {
+    marginBottom: '.8em',
+    ...media(
+      {
+        minWidth: ergonomics.LAP.BEGINNING,
+      },
+      {
+        marginBottom: 0,
+        marginRight: '.8em',
+      }
+    ),
+  },
+})
+
+const promptTransition = {
+  entering: { visibility: 'visible', transform: 'translateY(0)' },
+  entered: { visibility: 'visible', transform: 'translateY(0)' },
+  exiting: { visibility: 'visible' },
+}
+
+function Unsupported({ onDismiss }) {
+  const [displayInstructions, setDisplayInstructions] = useState(false)
+  const showInstructions = () => setDisplayInstructions(true)
+
+  return (
+    <>
+      {displayInstructions && (
+        <>
+          <p>If you are using Chrome, press the Menu button in the browser and Add to homescreen.</p>
+          <p>If you are using Safari, press the Share button in the browser and Add to Home Screen.</p>
+          <p>If you are using Opera, press the plus sign in top left and Add to home screen.</p>
+          <p>For any other browser please consult with documentation.</p>
+        </>
+      )}
+      <div className={styles.buttons}>
+        {!displayInstructions && (
+          <button className={classes(styles.button, styles.installButton)} onClick={showInstructions}>
+            Install
+          </button>
+        )}
+        <button className={styles.button} onClick={onDismiss}>
+          Close
+        </button>
+      </div>
+    </>
+  )
+}
+
+function Prompt({ display, onInstall, onDismiss, nativeSupport }) {
+  return (
+    <Transition in={display} timeout={300}>
+      {state => (
+        <div className={styles.wrapper} style={{ ...promptTransition[state] }}>
+          <h3 className={styles.title}>This app can be installed for offline use.</h3>
+
+          {nativeSupport && (
+            <div className={styles.buttons}>
+              <button className={classes(styles.button, styles.installButton)} onClick={onInstall}>
+                Install
+              </button>
+              <button className={styles.button} onClick={onDismiss}>
+                Close
+              </button>
+            </div>
+          )}
+
+          {!nativeSupport && <Unsupported onDismiss={onDismiss} />}
+        </div>
+      )}
+    </Transition>
+  )
+}
+
+export default Prompt

--- a/src/client/js/components/AddToHomescreen/Prompt.jsx
+++ b/src/client/js/components/AddToHomescreen/Prompt.jsx
@@ -39,6 +39,7 @@ const styles = stylesheet({
     background: colors.NEARFORM_BRAND_MAIN,
     color: 'white',
     fontSize: '1.1em',
+    cursor: 'pointer',
   },
   installButton: {
     marginBottom: '.8em',

--- a/src/client/js/components/AddToHomescreen/index.js
+++ b/src/client/js/components/AddToHomescreen/index.js
@@ -1,0 +1,1 @@
+export { default } from './AddToHomescreen'

--- a/src/client/js/components/AddToHomescreen/tests/AddToHomescreen.test.jsx
+++ b/src/client/js/components/AddToHomescreen/tests/AddToHomescreen.test.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import AddToHomescreen from '../AddToHomescreen'
+import { flushEffects } from '../../../utils/testUtils'
+
+const setup = () => {
+  const promptEvent = {
+    preventDefault: jest.fn(),
+  }
+  const event = new Event('beforeinstallprompt', promptEvent)
+  const test = mount(<AddToHomescreen />)
+  const originalUserAgent = navigator.userAgent
+
+  const cleanup = () => {
+    test.unmount()
+    Object.defineProperty(navigator, 'userAgent', { value: originalUserAgent, writable: true })
+  }
+
+  return { test, event, cleanup }
+}
+
+describe('AddToHomescreen', () => {
+  it('shouldnt render anything until effects are run', () => {
+    const test = mount(<AddToHomescreen />)
+    expect(test.isEmptyRender()).toEqual(true)
+    test.unmount()
+  })
+
+  it('should display prompt when browser triggers beforeinstallprompt event', () => {
+    const { test, event, cleanup } = setup()
+    flushEffects()
+
+    window.dispatchEvent(event)
+    flushEffects()
+    test.update()
+
+    expect(test.find('Prompt').props()).toMatchObject({ display: true })
+    cleanup()
+  })
+
+  it('should display prompt when beforeinstallprompt event is unsupported, but we still want to show fallback on mobile browsers', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: `Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X)
+    AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1`,
+      writable: true,
+    })
+
+    const { test, cleanup } = setup()
+    flushEffects()
+    test.update()
+
+    expect(test.find('Prompt').props()).toMatchObject({ display: true })
+
+    cleanup()
+  })
+})

--- a/src/client/js/components/AddToHomescreen/tests/AddToHomescreen.test.jsx
+++ b/src/client/js/components/AddToHomescreen/tests/AddToHomescreen.test.jsx
@@ -14,6 +14,7 @@ const setup = () => {
   const cleanup = () => {
     test.unmount()
     Object.defineProperty(navigator, 'userAgent', { value: originalUserAgent, writable: true })
+    Object.defineProperty(navigator, 'standalone', { value: undefined, writable: true })
   }
 
   return { test, event, cleanup }
@@ -50,6 +51,23 @@ describe('AddToHomescreen', () => {
     test.update()
 
     expect(test.find('Prompt').props()).toMatchObject({ display: true })
+
+    cleanup()
+  })
+
+  it('shouldnt display prompt when native event is unsupported, but the app was already installed and we are in standalone mode', () => {
+    Object.defineProperty(navigator, 'standalone', { value: true, writable: true })
+    Object.defineProperty(navigator, 'userAgent', {
+      value: `Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X)
+    AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1`,
+      writable: true,
+    })
+
+    const { test, cleanup } = setup()
+    flushEffects()
+    test.update()
+
+    expect(test.find('Prompt').props()).toMatchObject({ display: false })
 
     cleanup()
   })

--- a/src/client/js/components/AddToHomescreen/tests/Prompt.test.jsx
+++ b/src/client/js/components/AddToHomescreen/tests/Prompt.test.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { render, mount } from 'enzyme'
+import Prompt from '../Prompt'
+
+const setup = () => {
+  const props = { display: true, onInstall: jest.fn(), onDismiss: jest.fn() }
+  return props
+}
+
+describe('Prompt test suite', () => {
+  describe('natively supported', () => {
+    it('should render correctly', () => {
+      const props = setup()
+      const test = render(<Prompt {...props} nativeSupport />)
+
+      expect(test).toMatchSnapshot()
+    })
+
+    it('should call button callbacks', () => {
+      const props = setup()
+      const test = mount(<Prompt {...props} nativeSupport />)
+
+      test.find('button[children="Install"]').simulate('click')
+      expect(props.onInstall).toBeCalled()
+
+      test.find('button[children="Close"]').simulate('click')
+      expect(props.onDismiss).toBeCalled()
+    })
+  })
+
+  describe('not natively supported', () => {
+    it('should render correctly', () => {
+      const props = setup()
+      const test = render(<Prompt {...props} />)
+
+      expect(test).toMatchSnapshot()
+    })
+
+    it('should show instructions when clicking install', () => {
+      const props = setup()
+      const test = mount(<Prompt {...props} />)
+
+      test.find('button[children="Install"]').simulate('click')
+
+      expect(test).toMatchSnapshot()
+    })
+
+    it('should call button callbacks', () => {
+      const props = setup()
+      const test = mount(<Prompt {...props} />)
+
+      test.find('button[children="Close"]').simulate('click')
+      expect(props.onDismiss).toBeCalled()
+    })
+  })
+})

--- a/src/client/js/components/AddToHomescreen/tests/__snapshots__/Prompt.test.jsx.snap
+++ b/src/client/js/components/AddToHomescreen/tests/__snapshots__/Prompt.test.jsx.snap
@@ -14,12 +14,12 @@ exports[`Prompt test suite natively supported should render correctly 1`] = `
     class="buttons_f1dxplrk"
   >
     <button
-      class="button_fjoq4c1 installButton_f1wgjmrm"
+      class="button_f1h07t4x installButton_f1wgjmrm"
     >
       Install
     </button>
     <button
-      class="button_fjoq4c1"
+      class="button_f1h07t4x"
     >
       Close
     </button>
@@ -41,12 +41,12 @@ exports[`Prompt test suite not natively supported should render correctly 1`] = 
     class="buttons_f1dxplrk"
   >
     <button
-      class="button_fjoq4c1 installButton_f1wgjmrm"
+      class="button_f1h07t4x installButton_f1wgjmrm"
     >
       Install
     </button>
     <button
-      class="button_fjoq4c1"
+      class="button_f1h07t4x"
     >
       Close
     </button>
@@ -108,7 +108,7 @@ exports[`Prompt test suite not natively supported should show instructions when 
           className="buttons_f1dxplrk"
         >
           <button
-            className="button_fjoq4c1"
+            className="button_f1h07t4x"
             onClick={[MockFunction]}
           >
             Close

--- a/src/client/js/components/AddToHomescreen/tests/__snapshots__/Prompt.test.jsx.snap
+++ b/src/client/js/components/AddToHomescreen/tests/__snapshots__/Prompt.test.jsx.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Prompt test suite natively supported should render correctly 1`] = `
+<div
+  class="wrapper_fgxiik6"
+  style="visibility:visible;transform:translateY(0)"
+>
+  <h3
+    class="title_f5zh3yy"
+  >
+    This app can be installed for offline use.
+  </h3>
+  <div
+    class="buttons_f1dxplrk"
+  >
+    <button
+      class="button_fjoq4c1 installButton_f1wgjmrm"
+    >
+      Install
+    </button>
+    <button
+      class="button_fjoq4c1"
+    >
+      Close
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Prompt test suite not natively supported should render correctly 1`] = `
+<div
+  class="wrapper_fgxiik6"
+  style="visibility:visible;transform:translateY(0)"
+>
+  <h3
+    class="title_f5zh3yy"
+  >
+    This app can be installed for offline use.
+  </h3>
+  <div
+    class="buttons_f1dxplrk"
+  >
+    <button
+      class="button_fjoq4c1 installButton_f1wgjmrm"
+    >
+      Install
+    </button>
+    <button
+      class="button_fjoq4c1"
+    >
+      Close
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Prompt test suite not natively supported should show instructions when clicking install 1`] = `
+<Prompt
+  display={true}
+  onDismiss={[MockFunction]}
+  onInstall={[MockFunction]}
+>
+  <Transition
+    appear={false}
+    enter={true}
+    exit={true}
+    in={true}
+    mountOnEnter={false}
+    onEnter={[Function]}
+    onEntered={[Function]}
+    onEntering={[Function]}
+    onExit={[Function]}
+    onExited={[Function]}
+    onExiting={[Function]}
+    timeout={300}
+    unmountOnExit={false}
+  >
+    <div
+      className="wrapper_fgxiik6"
+      style={
+        Object {
+          "transform": "translateY(0)",
+          "visibility": "visible",
+        }
+      }
+    >
+      <h3
+        className="title_f5zh3yy"
+      >
+        This app can be installed for offline use.
+      </h3>
+      <Unsupported
+        onDismiss={[MockFunction]}
+      >
+        <p>
+          If you are using Chrome, press the Menu button in the browser and Add to homescreen.
+        </p>
+        <p>
+          If you are using Safari, press the Share button in the browser and Add to Home Screen.
+        </p>
+        <p>
+          If you are using Opera, press the plus sign in top left and Add to home screen.
+        </p>
+        <p>
+          For any other browser please consult with documentation.
+        </p>
+        <div
+          className="buttons_f1dxplrk"
+        >
+          <button
+            className="button_fjoq4c1"
+            onClick={[MockFunction]}
+          >
+            Close
+          </button>
+        </div>
+      </Unsupported>
+    </div>
+  </Transition>
+</Prompt>
+`;

--- a/src/client/js/components/Glyphs/Glyphs.jsx
+++ b/src/client/js/components/Glyphs/Glyphs.jsx
@@ -12,8 +12,8 @@ export const HumburgerIcon = () => (
   </svg>
 )
 
-export const CloseIcon = ({ width = 48, height = 48 }) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} aria-hidden="true">
+export const CloseIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" aria-hidden="true">
     <title>Close</title>
     <path
       fill={colors.NEARFORM_BRAND_MAIN}

--- a/src/client/js/components/Glyphs/Glyphs.jsx
+++ b/src/client/js/components/Glyphs/Glyphs.jsx
@@ -12,8 +12,8 @@ export const HumburgerIcon = () => (
   </svg>
 )
 
-export const CloseIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" aria-hidden="true">
+export const CloseIcon = ({ width = 48, height = 48 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} aria-hidden="true">
     <title>Close</title>
     <path
       fill={colors.NEARFORM_BRAND_MAIN}

--- a/src/client/js/components/Header/Header.jsx
+++ b/src/client/js/components/Header/Header.jsx
@@ -3,15 +3,9 @@ import { Link, NavLink } from 'react-router-dom'
 import FocusLock from 'react-focus-lock'
 import { Transition } from 'react-transition-group'
 import { media, stylesheet } from 'typestyle'
-import { colors, ergonomics } from '../../styles/common'
+import { colors, ergonomics, buttonReset } from '../../styles/common'
 import { Logo } from '../Logo'
 import { NearFormLogo, HumburgerIcon, CloseIcon } from '../Glyphs'
-
-const buttonReset = {
-  border: 'none',
-  background: 'none',
-  padding: 0,
-}
 
 const navigationTransition = {
   entering: { visibility: 'visible', transform: 'translateX(0)' },

--- a/src/client/js/components/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/client/js/components/Header/__snapshots__/Header.test.jsx.snap
@@ -68,7 +68,7 @@ exports[`renders correctly when location is "/" 1`] = `
   <button
     aria-describedby="nav-info"
     aria-label="Menu"
-    class="navigationHamburger_f18vijaj"
+    class="navigationHamburger_f1drioqs"
     data-testid="navigationHamburger"
   >
     <svg
@@ -183,7 +183,7 @@ exports[`renders correctly when location is "/" 1`] = `
       </ul>
       <button
         aria-label="Close"
-        class="navigationClose_frquig"
+        class="navigationClose_fqeebw7"
         data-testid="navigationClose"
       >
         <svg
@@ -320,7 +320,7 @@ exports[`renders correctly when location is "/newcomments" 1`] = `
   <button
     aria-describedby="nav-info"
     aria-label="Menu"
-    class="navigationHamburger_f18vijaj"
+    class="navigationHamburger_f1drioqs"
     data-testid="navigationHamburger"
   >
     <svg
@@ -435,7 +435,7 @@ exports[`renders correctly when location is "/newcomments" 1`] = `
       </ul>
       <button
         aria-label="Close"
-        class="navigationClose_frquig"
+        class="navigationClose_fqeebw7"
         data-testid="navigationClose"
       >
         <svg
@@ -572,7 +572,7 @@ exports[`should render with menu open 1`] = `
   <button
     aria-describedby="nav-info"
     aria-label="Menu"
-    class="navigationHamburger_f18vijaj"
+    class="navigationHamburger_f1drioqs"
     data-testid="navigationHamburger"
   >
     <svg
@@ -688,7 +688,7 @@ exports[`should render with menu open 1`] = `
       </ul>
       <button
         aria-label="Close"
-        class="navigationClose_frquig"
+        class="navigationClose_fqeebw7"
         data-testid="navigationClose"
       >
         <svg

--- a/src/client/js/hooks/index.js
+++ b/src/client/js/hooks/index.js
@@ -1,0 +1,1 @@
+export { default } from './useBeforeInstallPrompt'

--- a/src/client/js/hooks/index.js
+++ b/src/client/js/hooks/index.js
@@ -1,1 +1,1 @@
-export { default } from './useBeforeInstallPrompt'
+export { default as useBeforeInstallPrompt } from './useBeforeInstallPrompt'

--- a/src/client/js/hooks/tests/useBeforeInstallPrompt.test.js
+++ b/src/client/js/hooks/tests/useBeforeInstallPrompt.test.js
@@ -57,7 +57,7 @@ describe('useBeforeInstallPrompt hook', () => {
     cleanup()
   })
 
-  it('should call preventDefault on the event to prevent Chrome < 72 to automatically show dialog', () => {
+  it('should call preventDefault on the event to prevent Chrome < 68 to automatically show dialog', () => {
     const { test, cleanup } = setup()
     const testProps = test.find('TestComponent').props()
 

--- a/src/client/js/hooks/tests/useBeforeInstallPrompt.test.js
+++ b/src/client/js/hooks/tests/useBeforeInstallPrompt.test.js
@@ -46,14 +46,14 @@ const setup = () => {
 }
 
 describe('useBeforeInstallPrompt hook', () => {
-  it('should give us prompt, promptToInstall and promptSupported', () => {
+  it('should give us prompt, promptToInstall and nativeSupport', () => {
     const { test, cleanup } = setup()
     const testProps = test.find('TestComponent').props()
 
     expect(testProps.prompt).toBeDefined()
     expect(testProps.promptToInstall).toBeDefined()
-    expect(testProps.promptSupported).toBeDefined()
-    expect(testProps.promptSupported).toEqual(true)
+    expect(testProps.nativeSupport).toBeDefined()
+    expect(testProps.nativeSupport).toEqual(true)
     cleanup()
   })
 

--- a/src/client/js/hooks/tests/useBeforeInstallPrompt.test.js
+++ b/src/client/js/hooks/tests/useBeforeInstallPrompt.test.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import useBeforeInstallPrompt from '../useBeforeInstallPrompt'
+import { flushEffects } from '../../utils/testUtils'
+
+const Wrapper = ({ children }) => {
+  const data = useBeforeInstallPrompt()
+  return children(data)
+}
+
+const TestComponent = () => null
+const Test = () => <Wrapper>{data => <TestComponent {...data} />}</Wrapper>
+
+const setup = () => {
+  const promptEvent = {
+    preventDefault: jest.fn(),
+    prompt: jest.fn(),
+  }
+
+  // stub window.addEventListener
+  const originalAddEventListener = window.addEventListener
+  const events = {}
+  window.addEventListener = jest.fn((event, cb) => {
+    events[event] = cb
+  })
+
+  // stub BeforeInstallPromptEvent support
+  Object.defineProperty(window, 'BeforeInstallPromptEvent', { value: {}, writable: true })
+
+  const test = mount(<Test />)
+  // call all effects
+  flushEffects()
+
+  // simulate the event
+  events.beforeinstallprompt(promptEvent)
+  // rerender
+  test.update()
+
+  const cleanup = () => {
+    test.unmount()
+    window.addEventListener = originalAddEventListener
+    Object.defineProperty(window, 'BeforeInstallPromptEvent', { value: undefined, writable: true })
+  }
+
+  return { test, cleanup }
+}
+
+describe('useBeforeInstallPrompt hook', () => {
+  it('should give us prompt, promptToInstall and promptSupported', () => {
+    const { test, cleanup } = setup()
+    const testProps = test.find('TestComponent').props()
+
+    expect(testProps.prompt).toBeDefined()
+    expect(testProps.promptToInstall).toBeDefined()
+    expect(testProps.promptSupported).toBeDefined()
+    expect(testProps.promptSupported).toEqual(true)
+    cleanup()
+  })
+
+  it('should call preventDefault on the event to prevent Chrome < 72 to automatically show dialog', () => {
+    const { test, cleanup } = setup()
+    const testProps = test.find('TestComponent').props()
+
+    expect(testProps.prompt.preventDefault).toBeCalled()
+    cleanup()
+  })
+
+  it('should call prompt() on the original event when calling promptToInstall', () => {
+    const { test, cleanup } = setup()
+    const testProps = test.find('TestComponent').props()
+
+    testProps.promptToInstall()
+
+    expect(testProps.prompt.prompt).toBeCalled()
+    cleanup()
+  })
+})

--- a/src/client/js/hooks/useBeforeInstallPrompt.js
+++ b/src/client/js/hooks/useBeforeInstallPrompt.js
@@ -24,6 +24,6 @@ export default function useBeforeInstallPrompt() {
   return {
     prompt,
     promptToInstall,
-    promptSupported: env.canUseDOM && !!window.BeforeInstallPromptEvent,
+    nativeSupport: env.canUseDOM && !!window.BeforeInstallPromptEvent,
   }
 }

--- a/src/client/js/hooks/useBeforeInstallPrompt.js
+++ b/src/client/js/hooks/useBeforeInstallPrompt.js
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react'
+import env from 'exenv'
+
+export default function useBeforeInstallPrompt() {
+  const [prompt, setPrompt] = useState(null)
+
+  const promptToInstall = () => {
+    if (prompt) {
+      return prompt.prompt()
+    }
+    return Promise.reject(new Error('Tried installing before browser sent "beforeinstallprompt" event'))
+  }
+
+  useEffect(() => {
+    const ready = e => {
+      e.preventDefault()
+      setPrompt(e)
+    }
+
+    window.addEventListener('beforeinstallprompt', ready)
+    return () => window.removeEventListener('beforeinstallprompt', ready)
+  }, [])
+
+  return {
+    prompt,
+    promptToInstall,
+    promptSupported: env.canUseDOM && !!window.BeforeInstallPromptEvent,
+  }
+}

--- a/src/client/js/styles/common.js
+++ b/src/client/js/styles/common.js
@@ -25,6 +25,13 @@ export const placeholder = style(debugClassName('placeholder'), {
   background: `${constants.colors.LIGHT_GRAY} !important`,
 })
 
+export const buttonReset = {
+  border: 'none',
+  background: 'none',
+  padding: 0,
+  margin: 0,
+}
+
 export const loadingAnimation = style(debugClassName('loading'), {
   $nest: {
     '&::after': {


### PR DESCRIPTION
https://github.com/nearform/react-pwa/issues/88

Adds automatic add to homescreen prompt in supported browsers - currently only Android Chrome and desktop Chrome.
On desktop, you need to enable experimental flag #enable-desktop-pwas. Full support for desktop PWAs coming in Chrome v72.

In unsupported browsers we show a fallback with instructions on how to add to homescreen manually. I made it so that it is shown only on mobile browsers, since desktop PWAs are not yet supported anywhere.

How to test:
- I used Android emulator from Android Studio (can showcase a demo upon request)
- enable the experimental flag in Chrome
- if you are testing on Android Chrome, one of the requirements for it to appear is to be interacting with the page for at least 30 seconds (more or less)
- if running locally, you need to expose your localhost:3000 on some temporary domain with https enabled, I suggest this tool https://ngrok.com/